### PR TITLE
Automatic update of dependency redis from 2.10.3 to 2.10.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 -i https://pypi.org/simple
 amqp==2.3.2
+argcomplete==1.9.4
 billiard==3.5.0.3
 celery==4.0.0
 click==6.0
 codegen==1.0
 colorama==0.3.9
+flexmock==0.10.2
 graphviz==0.8.3
 jsonschema==2.6.0
 kombu==4.2.1
@@ -12,6 +14,6 @@ logutils==0.3.5
 pytz==2018.4
 pyyaml==3.12
 rainbow-logging-handler==2.2.2
-redis==2.10.3
+redis==2.10.6
 selinon==1.0.0rc2
 vine==1.1.4


### PR DESCRIPTION
Dependency redis was used in version 2.10.3, but the current latest version is 2.10.6.