### PR TITLE
Automatic update of dependency flask from 0.12.1 to 1.0.2

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c8a41cd23149d8570229a2eed908afaa5bae75e49fe6016fc820fbf55305748e"
+            "sha256": "8e2253c200e985600d3b8324694d5342b52871136d993c1ad4fbf65d6db89d92"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,11 +25,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:6c3130c8927109a08225993e4e503de4ac4f2678678ae211b33b519c622a7242",
-                "sha256:9dce4b6bfbb5b062181d3f7da8f727ff70c1156cbb4024351eafd426deb5fb88"
+                "sha256:2271c0070dbcb5275fad4a82e29f23ab92682dc45f9dfbc22c02ba9b9322ce48",
+                "sha256:a080b744b7e345ccfcbc77954861cb05b3c63786e93f2b3875e0913d44b43f05"
             ],
             "index": "pypi",
-            "version": "==0.12.1"
+            "version": "==1.0.2"
         },
         "itsdangerous": {
             "hashes": [


### PR DESCRIPTION
Dependency flask was used in version 0.12.1, but the current latest version is 1.0.2.